### PR TITLE
Adding functionality to limit what Git Runner is used for. Trying to …

### DIFF
--- a/Setup.ps1
+++ b/Setup.ps1
@@ -3768,9 +3768,9 @@ Push-Location $RepoRoot
 
     Write-Log "Dot sourcing Git Runner template script located at: $GitRunnerTemplate_ScriptPath" "INFO2"
 
-    if (!(Test-Path "$RepoRoot/.git")) {$TempURL = $OfficialPublicRepoURL} else {$TempURL = "ZZ"} # Dummy value to avoid errors if repo is not yet cloned.
+    if (!(Test-Path "$RepoRoot/.git")) {Write-Log "No local git repo initialized; will attempt to pull from $OfficialPublicRepoURL" "WARNING"; $TempURL = $OfficialPublicRepoURL} else {$TempURL = "ZZ"} # Dummy value to avoid errors if repo is not yet cloned. TODO: I should probably add the ability to select the DEV env too.
     & { # Run in a script block to avoid scope issues. Using ZZ as a dummy value for RepoURL since we are only updating local repo. Not the cleanest way to do this but it works for now. TODO: Clean up this method in the future.
-        . $GitRunnerTemplate_ScriptPath -RepoURL "$TempURL" -RepoNickName $ThisRepoNickName -WorkingDirectory $WorkingDirectory -UpdateLocalRepoOnly $true -StashChanges $False
+        . $GitRunnerTemplate_ScriptPath -RepoURL "$TempURL" -RepoNickName $ThisRepoNickName -WorkingDirectory $WorkingDirectory -StashChanges $False -InitOnly $True
 
         CheckAndInstall-Git
         Set-GitSafeDirectory

--- a/Templates/Git-Runner_TEMPLATE.ps1
+++ b/Templates/Git-Runner_TEMPLATE.ps1
@@ -100,6 +100,10 @@ param(
     
     [boolean]$UpdateLocalRepoOnly, # If true, script exits early after just updating
 
+    [boolean]$DotSourceOnly=$false, # If true, only dot sources the script without executing anything by exiting early
+
+    [boolean]$InitOnly=$false, # If true, only initializes the local repo without pulling or running anything. Exits early.
+
     [boolean]$StashChanges=$true, # If true, stashes any local changes before pulling latest commit
 
     [string]$ScriptPath, # Path from repo root to the target script
@@ -435,6 +439,13 @@ Function Set-GitSafeDirectory {
 ## Main ##
 ##########
 
+if ($DotSourceOnly -eq $true) {
+
+    Write-Host "DotSourceOnly is true; exiting script after dot sourcing." "INFO"
+    Exit 0
+
+}
+
 ## Pre-Check
 
 Write-Host "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -545,6 +556,13 @@ if(Test-Path $LocalRepoPath){
 
     }
    
+    if ($InitOnly -eq $true) {
+
+        Write-Log "InitOnly is true; exiting script after initializing local repo." "INFO"
+        Exit 0
+
+    }
+    
     Write-Log "Pulling latest changes..."
     try {
 


### PR DESCRIPTION
…tighten up the self update functionality. I noticed with the previous commit the repo would self update without notifying the user. So now it won't pull during the dot sourcing just init.