### PR TITLE
Fix Git reinstalling on every run and restore mutex guard

### DIFF
--- a/Templates/Git-Runner_TEMPLATE.ps1
+++ b/Templates/Git-Runner_TEMPLATE.ps1
@@ -337,6 +337,12 @@ function Test-PathSyntaxValidity {
 }
 
 function CheckAndInstall-Git {
+
+    # Refresh PATH from the registry before checking — this process may have started before a
+    # previous run installed Git and updated the system PATH, so without this refresh every run
+    # would see "git not found" even though Git is already on disk.
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
         Write-Log "Git not found. Acquiring mutex lock for installation..." "WARNING"
 
@@ -362,7 +368,10 @@ function CheckAndInstall-Git {
 
             Write-Log "Mutex acquired. Checking Git again..."
 
-            # Re-check after acquiring mutex — another instance may have installed Git while waiting
+            # Re-check after acquiring — refresh PATH first so we don't miss a Git install that
+            # another process completed while we were waiting for the mutex.
+            $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
             if (Get-Command git -ErrorAction SilentlyContinue) {
                 Write-Log "Git was installed by another process while waiting."
                 return
@@ -419,7 +428,7 @@ function CheckAndInstall-Git {
             if ($mutex) {
 
                 $mutex.Dispose()
-               
+
             }
         }
     } else {


### PR DESCRIPTION
Two bugs in CheckAndInstall-Git:

1. PATH was only refreshed *after* installation, never before the initial Get-Command check. Because the RMM agent process inherits the PATH snapshot from when the service started, it never sees Git even after a successful install on the previous hourly run — causing a 2-4 minute reinstall on every cycle. Fix: refresh PATH from the registry at the top of the function before any git check.

2. The named-mutex guard that prevents concurrent installs (present in older generated wrapper scripts) was missing from the template. Two simultaneous RMM jobs could both detect "git not found" and race to install. Fix: wrap the install block in Global\PowerDeploy_GitInstall with a double-check after acquiring (in case a concurrent process finished while waiting).